### PR TITLE
add apt-get update to apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3
 
-RUN apt-get update && apt-get install -y build-essential
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 RUN conda create -n scenic python=3.6.7
 RUN echo "source activate scenic" > ~/.bashrc
 ENV PATH /opt/conda/envs/scenic/bin:$PATH
@@ -9,7 +9,7 @@ RUN pip install --no-cache-dir --upgrade pyscenic dask==1.0.0 pandas==0.23.4
 LABEL version=0.1
 
 # Install dependencies: fwatchdog, yq and porta.sh
-RUN apt-get install -y curl bash \
+RUN apt-get update && apt-get install -y --no-install-recommends curl bash \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \


### PR DESCRIPTION
If you build this dockerfile, wait a while (1 month?), change something between lines 3 and 12, then rebuild the dockerfile, you get the following error:

```
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package curl
```

Doing an apt-get update before a RUN command containing an apt-get install will fix this problem.